### PR TITLE
fix hover filtering

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -131,7 +131,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                     if (groundItem != null)
                     {
                         var doWePickThis = Settings.PickUpEverything || (_itemFilters?.Any(filter =>
-                            filter.Matches(new ItemData(groundItem.ItemOnGround, GameController))) ?? false);
+                            filter.Matches(new ItemData(groundItem, GameController))) ?? false);
                         if (doWePickThis && groundItem?.ItemOnGround.DistancePlayer < 20f)
                         {
                             _sinceLastClick.Restart();


### PR DESCRIPTION
Hover pick was working only with PickUpEverything enabled. In my case, I had it disabled and wanted to hover pick only the items on my filter and this feature wasn't working. This little change fixed the problem in my case.