### PR TITLE
Fix opening of chests & add support for opening doors

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -226,12 +226,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         bool IsFittingEntity(Entity entity)
         {
             return entity?.Path is { } path &&
-                   (Settings.ClickQuestChests && path.StartsWith("Metadata/Chests/QuestChests/", StringComparison.Ordinal) ||
-                    path.StartsWith("Metadata/Chests/LeaguesExpedition/", StringComparison.Ordinal) ||
-                    path.StartsWith("Metadata/Chests/LegionChests/", StringComparison.Ordinal) ||
-                    path.StartsWith("Metadata/Chests/Blight", StringComparison.Ordinal) ||
-                    path.StartsWith("Metadata/Chests/Breach/", StringComparison.Ordinal) ||
-                    path.StartsWith("Metadata/Chests/IncursionChest", StringComparison.Ordinal)) &&
+                   (Settings.ClickChests && path.StartsWith("Metadata/Chests", StringComparison.Ordinal)) &&
                    entity.HasComponent<Chest>();
         }
 

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -28,6 +28,7 @@ namespace PickIt;
 public partial class PickIt : BaseSettingsPlugin<PickItSettings>
 {
     private readonly CachedValue<List<LabelOnGround>> _chestLabels;
+    private readonly CachedValue<List<LabelOnGround>> _doorLabels;
     private readonly CachedValue<LabelOnGround> _portalLabel;
     private readonly CachedValue<List<LabelOnGround>> _corpseLabels;
     private readonly CachedValue<bool[,]> _inventorySlotsCache;
@@ -45,6 +46,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
     {
         _inventorySlotsCache = new FrameCache<bool[,]>(() => GetContainer2DArray(_inventoryItems));
         _chestLabels = new TimeCache<List<LabelOnGround>>(UpdateChestList, 200);
+        _doorLabels = new TimeCache<List<LabelOnGround>>(UpdateDoorList, 200);
         _corpseLabels = new TimeCache<List<LabelOnGround>>(UpdateCorpseList, 200);
         _portalLabel = new TimeCache<LabelOnGround>(() => GetLabel(@"^Metadata/(MiscellaneousObjects|Effects/Microtransactions)/.*Portal"), 200);
     }
@@ -228,6 +230,27 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
             return entity?.Path is { } path &&
                    (path.StartsWith("Metadata/Chests", StringComparison.Ordinal)) &&
                    entity.HasComponent<Chest>();
+        }
+
+        if (GameController.EntityListWrapper.OnlyValidEntities.Any(IsFittingEntity))
+        {
+            return GameController?.Game?.IngameState?.IngameUi?.ItemsOnGroundLabelsVisible
+                .Where(x => x.Address != 0 &&
+                            x.IsVisible &&
+                            IsFittingEntity(x.ItemOnGround))
+                .OrderBy(x => x.ItemOnGround.DistancePlayer)
+                .ToList() ?? [];
+        }
+
+        return [];
+    }
+
+    private List<LabelOnGround> UpdateDoorList()
+    {
+        bool IsFittingEntity(Entity entity)
+        {
+            return entity?.Path is { } path &&
+                   path.Contains("DoorRandom", StringComparison.Ordinal);
         }
 
         if (GameController.EntityListWrapper.OnlyValidEntities.Any(IsFittingEntity))
@@ -446,6 +469,19 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                 if (chestLabel != null && (pickUpThisItem == null || pickUpThisItem.Distance >= chestLabel.ItemOnGround.DistancePlayer))
                 {
                     await PickAsync(chestLabel.ItemOnGround, chestLabel.Label, null, _chestLabels.ForceUpdate);
+                    return true;
+                }
+            }
+
+            if (Settings.ClickDoors)
+            {
+                var chestLabel = _doorLabels?.Value.FirstOrDefault(x =>
+                    x.ItemOnGround.DistancePlayer < Settings.PickupRange &&
+                    IsLabelClickable(x.Label, null));
+
+                if (chestLabel != null && (pickUpThisItem == null || pickUpThisItem.Distance >= chestLabel.ItemOnGround.DistancePlayer))
+                {
+                    await PickAsync(chestLabel.ItemOnGround, chestLabel.Label, null, _doorLabels.ForceUpdate);
                     return true;
                 }
             }

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -226,7 +226,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         bool IsFittingEntity(Entity entity)
         {
             return entity?.Path is { } path &&
-                   (Settings.ClickChests && path.StartsWith("Metadata/Chests", StringComparison.Ordinal)) &&
+                   (path.StartsWith("Metadata/Chests", StringComparison.Ordinal)) &&
                    entity.HasComponent<Chest>();
         }
 

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -29,6 +29,7 @@ public class PickItSettings : ISettings
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);
+    public ToggleNode ClickDoors { get; set; } = new ToggleNode(true);
     public ToggleNode ItemizeCorpses { get; set; } = new ToggleNode(true);
 
     [JsonIgnore]

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -45,6 +45,7 @@ public class PickItSettings : ISettings
     [JsonIgnore]
     public FilterNode Filters { get; } = new FilterNode();
 
+    [Menu(null, "For debugging. Highlights items if they match an existing filter")]
     [JsonIgnore]
     public ToggleNode DebugHighlight { get; set; } = new ToggleNode(false);
 }

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -29,7 +29,6 @@ public class PickItSettings : ISettings
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);
-    public ToggleNode ClickQuestChests { get; set; } = new ToggleNode(true);
     public ToggleNode ItemizeCorpses { get; set; } = new ToggleNode(true);
 
     [JsonIgnore]


### PR DESCRIPTION
* Removed individual chests from hardcoded list
* Instead will check if entity has chest component as well as a more generic metadata path
* Removed quest chests since (I think) they're obsolete now
* Added info text to Debug Highlight to clarify what it does
* Added 'Click Doors' option to open most doors