### PR TITLE
New Feature: Option to disable pickit while monsters nearby

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -220,6 +220,12 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
 
     private bool DoWePickThis(PickItItemData item)
     {
+        if (Settings.NoLootingWhileEnemyClose && GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Monster]
+                    .Any(x => x?.GetComponent<Monster>() != null && x.IsValid && x.IsHostile && x.IsAlive
+                              && !x.IsHidden && !x.Path.Contains("ElementalSummoned")
+                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupRange)) 
+                return false;
+
         return Settings.PickUpEverything || (_itemFilters?.Any(filter => filter.Matches(item)) ?? false);
     }
 

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -218,13 +218,21 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         }
     }
 
-    private bool DoWePickThis(PickItItemData item)
+    private bool IsItSafeToPickit()
     {
         if (Settings.NoLootingWhileEnemyClose && GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Monster]
                     .Any(x => x?.GetComponent<Monster>() != null && x.IsValid && x.IsHostile && x.IsAlive
                               && !x.IsHidden && !x.Path.Contains("ElementalSummoned")
-                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupRange)) 
-                return false;
+                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupRange))
+            return false;
+        else
+            return true;
+    }
+
+    private bool DoWePickThis(PickItItemData item)
+    {
+        if (!IsItSafeToPickit())
+            return false;
 
         return Settings.PickUpEverything || (_itemFilters?.Any(filter => filter.Matches(item)) ?? false);
     }
@@ -237,6 +245,9 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                    (path.StartsWith("Metadata/Chests", StringComparison.Ordinal)) &&
                    entity.HasComponent<Chest>();
         }
+
+        if (!IsItSafeToPickit())
+            return [];
 
         if (GameController.EntityListWrapper.OnlyValidEntities.Any(IsFittingEntity))
         {
@@ -261,6 +272,9 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                     path.Contains("WaterLevelLever", StringComparison.Ordinal));
         }
 
+        if (!IsItSafeToPickit())
+            return [];
+
         if (GameController.EntityListWrapper.OnlyValidEntities.Any(IsFittingEntity))
         {
             return GameController?.Game?.IngameState?.IngameUi?.ItemsOnGroundLabelsVisible
@@ -280,6 +294,9 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         {
             return entity?.Path is "Metadata/Terrain/Leagues/Necropolis/Objects/NecropolisCorpseMarker";
         }
+
+        if (!IsItSafeToPickit())
+            return [];
 
         if (GameController.EntityListWrapper.OnlyValidEntities.Any(IsFittingEntity))
         {

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -27,7 +27,7 @@ public class PickItSettings : ISettings
     public ToggleNode LazyLooting { get; set; } = new ToggleNode(false);
     [Menu("No Lazy Looting While Enemy Close", "Will disable Lazy Looting while enemies close by")]
     public ToggleNode NoLazyLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
-    [Menu("No Looting While Enemy Close", "Will disable keypress pickit looting while enemies close by")]
+    [Menu("No Looting While Enemy Close", "Will disable keypress pickit while enemies close by")]
     public ToggleNode NoLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -25,7 +25,10 @@ public class PickItSettings : ISettings
     public RangeNode<int> PauseBetweenClicks { get; set; } = new RangeNode<int>(100, 0, 500);
     public ToggleNode AutoClickHoveredLootInRange { get; set; } = new ToggleNode(false);
     public ToggleNode LazyLooting { get; set; } = new ToggleNode(false);
+    [Menu("No Lazy Looting While Enemy Close", "Will disable Lazy Looting while enemies close by")]
     public ToggleNode NoLazyLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
+    [Menu("No Looting While Enemy Close", "Will disable keypress pickit looting while enemies close by")]
+    public ToggleNode NoLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);


### PR DESCRIPTION
* Add an optional safety check to disable manual/keypress pickit while hostile enemies nearby. (No change to lazy looting)
* Applies to corpses, chests, and doors/levers as well. 
* Updated relevant menu descriptors