### PR TITLE
PluginBridge & Clicker improvements

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -340,10 +340,18 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
 
     private bool ShouldLazyLoot(PickItItemData item)
     {
-        if (item == null)
+        if (Settings.LazyLooting && Settings.ClickDoors)
         {
-            return false;
+            foreach (var door in _doorLabels.Value)
+            {
+                if (door.ItemOnGround.DistancePlayer < 25)
+                {
+                    return true;
+                }
+            }
         }
+        if (item == null)
+            return false;
 
         var itemPos = item.QueriedItem.Entity.Pos;
         var playerPos = GameController.Player.Pos;

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -30,6 +30,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
     private readonly CachedValue<List<LabelOnGround>> _chestLabels;
     private readonly CachedValue<List<LabelOnGround>> _doorLabels;
     private readonly CachedValue<LabelOnGround> _portalLabel;
+    private readonly CachedValue<LabelOnGround> _transitionLabel;
     private readonly CachedValue<List<LabelOnGround>> _corpseLabels;
     private readonly CachedValue<bool[,]> _inventorySlotsCache;
     private ServerInventory _inventoryItems;
@@ -49,6 +50,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         _doorLabels = new TimeCache<List<LabelOnGround>>(UpdateDoorList, 200);
         _corpseLabels = new TimeCache<List<LabelOnGround>>(UpdateCorpseList, 200);
         _portalLabel = new TimeCache<LabelOnGround>(() => GetLabel(@"^Metadata/(MiscellaneousObjects|Effects/Microtransactions)/.*Portal"), 200);
+        _transitionLabel = new TimeCache<LabelOnGround>(() => GetLabel(@"Metadata/MiscellaneousObjects/AreaTransition_Animate"), 200);
     }
 
     public override bool Initialise()
@@ -340,11 +342,22 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
 
     private bool ShouldLazyLoot(PickItItemData item)
     {
-        if (Settings.LazyLooting && Settings.ClickDoors)
+        if (Settings.LazyLooting)
         {
-            foreach (var door in _doorLabels.Value)
+            if (Settings.ClickDoors)
             {
-                if (door.ItemOnGround.DistancePlayer < 25)
+                foreach (var door in _doorLabels.Value)
+                {
+                    if (door.ItemOnGround.DistancePlayer < 15)
+                    {
+                        return true;
+                    }
+                }
+            }
+            if (Settings.ClickTransitions)
+            {
+                var transitionLabel = _transitionLabel?.Value;
+                if (transitionLabel != null && transitionLabel.ItemOnGround.DistancePlayer < 15)
                 {
                     return true;
                 }
@@ -545,7 +558,17 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                 }
             }
 
-            if (pickUpThisItem == null)
+            if (Settings.ClickTransitions)
+            {
+                var transitionLabel = _transitionLabel?.Value;
+                if (transitionLabel != null && (pickUpThisItem == null || pickUpThisItem.Distance >= transitionLabel.ItemOnGround.DistancePlayer))
+                {
+                    await PickAsync(transitionLabel.ItemOnGround, transitionLabel.Label, null, _portalLabel.ForceUpdate);
+                    return true;
+                }
+            }
+
+                if (pickUpThisItem == null)
             {
                 return true;
             }

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -33,6 +33,8 @@ public class PickItSettings : ISettings
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);
     public ToggleNode ClickDoors { get; set; } = new ToggleNode(true);
+    [Menu("Click Transitions", "Will click area/zone transitions if enabled")]
+    public ToggleNode ClickTransitions { get; set; } = new ToggleNode(true);
     public ToggleNode ItemizeCorpses { get; set; } = new ToggleNode(true);
 
     [JsonIgnore]

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -30,6 +30,7 @@ public class PickItSettings : ISettings
     [Menu("No Looting While Enemy Close", "Will disable keypress pickit while enemies close by")]
     public ToggleNode NoLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
+    public ToggleNode ShouldPickitWarnTheBridge { get; set; } = new ToggleNode(true);
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);
     public ToggleNode ClickDoors { get; set; } = new ToggleNode(true);


### PR DESCRIPTION
* Add a basic warning beacon to the plugin bridge so other plugins can be aware of its activity (is it picking currently)
* Expand/improve door-clicker (Part 1)
* Add a transition clicker to change between zones


In a future master commit I massively rewrote large swathes, and improved the door/transition clicker even further. Which will be supplied in one of the next two PR's