### PR TITLE
Safe Range Pickup Range Selector

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -277,7 +277,8 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
             return entity?.Path is { } path && (
                     path.Contains("DoorRandom", StringComparison.Ordinal) ||
                     path.Contains("Door", StringComparison.Ordinal) ||
-                    path.Contains("Endgame/TowerCompletion", StringComparison.Ordinal) ||
+                    path.Contains("AreaTransition_Animate", StringComparison.Ordinal) ||
+                    path.Contains("TowerCompletion", StringComparison.Ordinal) ||
                     path.Contains("WaterLevelLever", StringComparison.Ordinal));
         }
 

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -239,7 +239,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         if (Settings.NoLootingWhileEnemyClose && GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Monster]
                     .Any(x => x?.GetComponent<Monster>() != null && x.IsValid && x.IsHostile && x.IsAlive
                               && !x.IsHidden && !x.Path.Contains("ElementalSummoned")
-                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupRange))
+                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupSafeRange))
             return false;
         else
             return true;

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -19,8 +19,8 @@ public class PickItSettings : ISettings
     public HotkeyNode ProfilerHotkey { get; set; } = Keys.None;
     public HotkeyNode PickUpKey { get; set; } = Keys.F;
     public ToggleNode PickUpWhenInventoryIsFull { get; set; } = new ToggleNode(false);
-    public RangeNode<int> PickupRange { get; set; } = new RangeNode<int>(600, 1, 2500);
-    public RangeNode<int> PickupSafeRange { get; set; } = new RangeNode<int>(600, 1, 2500);
+    public RangeNode<int> PickupRange { get; set; } = new RangeNode<int>(500, 1, 2500);
+    public RangeNode<int> PickupSafeRange { get; set; } = new RangeNode<int>(1000, 1, 2500);
     public ToggleNode IgnoreMoving { get; set; } = new ToggleNode(false);
     public RangeNode<int> ItemDistanceToIgnoreMoving { get; set; } = new RangeNode<int>(20, 0, 1000);
     public RangeNode<int> PauseBetweenClicks { get; set; } = new RangeNode<int>(100, 0, 500);

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -19,8 +19,8 @@ public class PickItSettings : ISettings
     public HotkeyNode ProfilerHotkey { get; set; } = Keys.None;
     public HotkeyNode PickUpKey { get; set; } = Keys.F;
     public ToggleNode PickUpWhenInventoryIsFull { get; set; } = new ToggleNode(false);
-    public RangeNode<int> PickupRange { get; set; } = new RangeNode<int>(600, 1, 1000);
-    public RangeNode<int> PickupSafeRange { get; set; } = new RangeNode<int>(600, 1, 1000);
+    public RangeNode<int> PickupRange { get; set; } = new RangeNode<int>(600, 1, 2500);
+    public RangeNode<int> PickupSafeRange { get; set; } = new RangeNode<int>(600, 1, 2500);
     public ToggleNode IgnoreMoving { get; set; } = new ToggleNode(false);
     public RangeNode<int> ItemDistanceToIgnoreMoving { get; set; } = new RangeNode<int>(20, 0, 1000);
     public RangeNode<int> PauseBetweenClicks { get; set; } = new RangeNode<int>(100, 0, 500);

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -20,6 +20,7 @@ public class PickItSettings : ISettings
     public HotkeyNode PickUpKey { get; set; } = Keys.F;
     public ToggleNode PickUpWhenInventoryIsFull { get; set; } = new ToggleNode(false);
     public RangeNode<int> PickupRange { get; set; } = new RangeNode<int>(600, 1, 1000);
+    public RangeNode<int> PickupSafeRange { get; set; } = new RangeNode<int>(600, 1, 1000);
     public ToggleNode IgnoreMoving { get; set; } = new ToggleNode(false);
     public RangeNode<int> ItemDistanceToIgnoreMoving { get; set; } = new RangeNode<int>(20, 0, 1000);
     public RangeNode<int> PauseBetweenClicks { get; set; } = new RangeNode<int>(100, 0, 500);


### PR DESCRIPTION
Added a variable that specifically controls IsItSafeToPickUp for the user to change the distance monsters have to be from the player for PickIt to be active.

Heavily tested, no bugs found, please still check the code before as I'm not a programmer.