### PR TITLE
Upgrades, fixes, and organization changes (mostly related to 'misc pickit')

### DIFF
--- a/PickIt.cs
+++ b/PickIt.cs
@@ -51,7 +51,6 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         _chestLabels = new TimeCache<List<LabelOnGround>>(UpdateChestList, 200);
         _doorLabels = new TimeCache<List<LabelOnGround>>(UpdateDoorList, 200);
         _corpseLabels = new TimeCache<List<LabelOnGround>>(UpdateCorpseList, 200);
-        _shrineLabels = new TimeCache<List<LabelOnGround>>(UpdateShrineList, 200);
         _portalLabels = new TimeCache<List<LabelOnGround>>(UpdatePortalList, 200);
         _transitionLabel = new TimeCache<LabelOnGround>(() => GetLabel(@"Metadata/MiscellaneousObjects/AreaTransition_Animate"), 200);
     }
@@ -351,31 +350,6 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                 .OrderBy(x => x.ItemOnGround.DistancePlayer)
                 .ToList() ?? [];
         }
-        return [];
-    }
-
-    private List<LabelOnGround> UpdateShrineList()
-    {
-        bool IsFittingEntity(Entity entity)
-        {
-            return entity?.Path is { } path && 
-                (path.StartsWith("Metadata/Shrines/Shrine", StringComparison.Ordinal)) ||
-                entity.HasComponent<Shrine>();
-        }
-
-        if (!IsItSafeToPickit())
-            return [];
-
-        if (GameController.EntityListWrapper.OnlyValidEntities.Any(IsFittingEntity))
-        {
-            return GameController?.Game?.IngameState?.IngameUi?.ItemsOnGroundLabelsVisible
-                .Where(x => x.Address != 0 &&
-                            x.IsVisible &&
-                            IsFittingEntity(x.ItemOnGround))
-                .OrderBy(x => x.ItemOnGround.DistancePlayer)
-                .ToList() ?? [];
-        }
-
         return [];
     }
 

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -121,7 +121,6 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         if (playerInvCount is null or 0)
             return;
 
-        #region HoverPickit
         if (Settings.AutoClickHoveredLootInRange.Value)
         {
             var hoverItemIcon = UIHoverWithFallback.AsObject<HoverItemIcon>();
@@ -146,7 +145,6 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                 }
             }
         }
-        #endregion
 
         _inventoryItems = GameController.Game.IngameState.Data.ServerData.PlayerInventories[0].Inventory;
         DrawIgnoredCellsSettings();
@@ -616,7 +614,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                     return true;
                 }
 
-                if (!Settings.IgnoreMoving && GameController.Player.GetComponent<Actor>().isMoving)
+                if (Settings.IgnoreMoving && GameController.Player.GetComponent<Actor>().isMoving)
                 {
                     if (item.DistancePlayer > Settings.ItemDistanceToIgnoreMoving.Value)
                     {

--- a/PickIt.cs
+++ b/PickIt.cs
@@ -239,7 +239,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         if (Settings.NoLootingWhileEnemyClose && GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Monster]
                     .Any(x => x?.GetComponent<Monster>() != null && x.IsValid && x.IsHostile && x.IsAlive
                               && !x.IsHidden && !x.Path.Contains("ElementalSummoned")
-                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupRange))
+                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.ItemPickitRange))
             return false;
         else
             return true;
@@ -258,7 +258,8 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         bool IsFittingEntity(Entity entity)
         {
             return entity?.Path is { } path &&
-                   (path.StartsWith("Metadata/Chests", StringComparison.Ordinal)) &&
+                   (path.StartsWith("Metadata/Chests", StringComparison.Ordinal) ||
+                   path.Contains("CampsiteChest", StringComparison.Ordinal)) &&
                    entity.HasComponent<Chest>();
         }
 
@@ -337,7 +338,8 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
             if (Settings.NoLazyLootingWhileEnemyClose && GameController.EntityListWrapper.ValidEntitiesByType[EntityType.Monster]
                     .Any(x => x?.GetComponent<Monster>() != null && x.IsValid && x.IsHostile && x.IsAlive
                               && !x.IsHidden && !x.Path.Contains("ElementalSummoned")
-                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.PickupRange)) return false;
+                              && Vector3.Distance(GameController.Player.Pos, x.GetComponent<Render>().Pos) < Settings.ItemPickitRange)) 
+                return false;
         }
         catch (NullReferenceException)
         {
@@ -369,6 +371,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
                 }
             }
         }
+
         if (item == null)
             return false;
 
@@ -384,9 +387,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
             return false;
 
         if (label == null)
-        {
             return false;
-        }
 
         var itemPos = label.ItemOnGround.Pos;
         var playerPos = GameController.Player.Pos;
@@ -525,10 +526,10 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
         if (workMode == WorkMode.Manual || workMode == WorkMode.Lazy && (ShouldLazyLoot(pickUpThisItem) ||
             ShouldLazyLootDoorOrChest(_doorLabels.Value.FirstOrDefault()) || ShouldLazyLootDoorOrChest(_chestLabels.Value.FirstOrDefault())))
         {
-            if (Settings.ItemizeCorpses)
+            if (Settings.ClickCorpses)
             {
                 var corpseLabel = _corpseLabels?.Value.FirstOrDefault(x =>
-                    x.ItemOnGround.DistancePlayer < Settings.PickupRange &&
+                    x.ItemOnGround.DistancePlayer < Settings.ItemPickitRange &&
                     IsLabelClickable(x.Label, null));
 
                 if (corpseLabel != null)
@@ -541,7 +542,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
             if (Settings.ClickDoors)
             {
                 var doorLabel = _doorLabels?.Value.FirstOrDefault(x =>
-                    x.ItemOnGround.DistancePlayer < Settings.PickupRange &&
+                    x.ItemOnGround.DistancePlayer < Settings.ItemPickitRange &&
                     IsLabelClickable(x.Label, null));
 
                 if (doorLabel != null && (pickUpThisItem == null || pickUpThisItem.Distance >= doorLabel.ItemOnGround.DistancePlayer))
@@ -554,7 +555,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
             if (Settings.ClickChests)
             {
                 var chestLabel = _chestLabels?.Value.FirstOrDefault(x =>
-                    x.ItemOnGround.DistancePlayer < Settings.PickupRange &&
+                    x.ItemOnGround.DistancePlayer < Settings.ItemPickitRange &&
                     IsLabelClickable(x.Label, null));
 
                 if (chestLabel != null && (pickUpThisItem == null || pickUpThisItem.Distance >= chestLabel.ItemOnGround.DistancePlayer))
@@ -589,7 +590,7 @@ public partial class PickIt : BaseSettingsPlugin<PickItSettings>
     private IEnumerable<PickItItemData> GetItemsToPickup(bool filterAttempts)
     {
         var labels = GameController.Game.IngameState.IngameUi.ItemsOnGroundLabelElement.VisibleGroundItemLabels?
-            .Where(x=> x.Entity?.DistancePlayer is {} distance && distance < Settings.PickupRange)
+            .Where(x=> x.Entity?.DistancePlayer is {} distance && distance < Settings.ItemPickitRange)
             .OrderBy(x => x.Entity?.DistancePlayer ?? int.MaxValue);
 
         return labels?

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -19,9 +19,12 @@ public class PickItSettings : ISettings
     public HotkeyNode ProfilerHotkey { get; set; } = Keys.None;
     public HotkeyNode PickUpKey { get; set; } = Keys.F;
     public ToggleNode PickUpWhenInventoryIsFull { get; set; } = new ToggleNode(false);
-    public RangeNode<int> PickupRange { get; set; } = new RangeNode<int>(600, 1, 1000);
+    public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
+    [Menu("Item Pickit Range", "Range at which we will attempt to pickit")]
+    public RangeNode<int> ItemPickitRange { get; set; } = new RangeNode<int>(600, 1, 1000);
     public ToggleNode IgnoreMoving { get; set; } = new ToggleNode(false);
     public RangeNode<int> ItemDistanceToIgnoreMoving { get; set; } = new RangeNode<int>(20, 0, 1000);
+    [Menu("Pause Between Clicks", "How many milliseconds to wait between clicks")]
     public RangeNode<int> PauseBetweenClicks { get; set; } = new RangeNode<int>(100, 0, 500);
     public ToggleNode AutoClickHoveredLootInRange { get; set; } = new ToggleNode(false);
     public ToggleNode LazyLooting { get; set; } = new ToggleNode(false);
@@ -30,12 +33,14 @@ public class PickItSettings : ISettings
     [Menu("No Looting While Enemy Close", "Will disable keypress pickit while enemies close by")]
     public ToggleNode NoLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
-    public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
+    [Menu("Click Chests", "Will click chests if enabled")]
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);
+    [Menu("Click Doors", "Will click doors if enabled")]
     public ToggleNode ClickDoors { get; set; } = new ToggleNode(true);
     [Menu("Click Transitions", "Will click area/zone transitions if enabled")]
     public ToggleNode ClickTransitions { get; set; } = new ToggleNode(true);
-    public ToggleNode ItemizeCorpses { get; set; } = new ToggleNode(true);
+    [Menu("Click Corpses", "Will click corpses if enabled")]
+    public ToggleNode ClickCorpses { get; set; } = new ToggleNode(true);
 
     [JsonIgnore]
     public TextNode FilterTest { get; set; } = new TextNode();

--- a/PickItSettings.cs
+++ b/PickItSettings.cs
@@ -22,25 +22,43 @@ public class PickItSettings : ISettings
     public ToggleNode PickUpEverything { get; set; } = new ToggleNode(false);
     [Menu("Item Pickit Range", "Range at which we will attempt to pickit")]
     public RangeNode<int> ItemPickitRange { get; set; } = new RangeNode<int>(600, 1, 1000);
-    public ToggleNode IgnoreMoving { get; set; } = new ToggleNode(false);
-    public RangeNode<int> ItemDistanceToIgnoreMoving { get; set; } = new RangeNode<int>(20, 0, 1000);
     [Menu("Pause Between Clicks", "How many milliseconds to wait between clicks")]
     public RangeNode<int> PauseBetweenClicks { get; set; } = new RangeNode<int>(100, 0, 500);
+    public ToggleNode IgnoreMoving { get; set; } = new ToggleNode(false);
+    [ConditionalDisplay(nameof(IgnoreMoving), true)]
+    public RangeNode<int> ItemDistanceToIgnoreMoving { get; set; } = new RangeNode<int>(20, 0, 1000);
+    [Menu("Auto Click Hovered Loot In Range", "Auto pick up any hovered items that matches filters or pickup everything if the 'pickup everything' option is enabled")]
     public ToggleNode AutoClickHoveredLootInRange { get; set; } = new ToggleNode(false);
     public ToggleNode LazyLooting { get; set; } = new ToggleNode(false);
+    [ConditionalDisplay(nameof(LazyLooting), true)]
     [Menu("No Lazy Looting While Enemy Close", "Will disable Lazy Looting while enemies close by")]
     public ToggleNode NoLazyLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
-    [Menu("No Looting While Enemy Close", "Will disable keypress pickit while enemies close by")]
-    public ToggleNode NoLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
+    [ConditionalDisplay(nameof(LazyLooting), true)]
     public HotkeyNode LazyLootingPauseKey { get; set; } = new HotkeyNode(Keys.Space);
+    [Menu("No Looting While Enemy Close", "Will disable pickit while enemies close by (this includes lazylooting as well as manual pickit)")]
+    public ToggleNode NoLootingWhileEnemyClose { get; set; } = new ToggleNode(false);
+    [Menu("Miscellaneous Pickit Options", "Pickit will click Doors, Chests, Corpses, Transitions, Portals")]
+    public ToggleNode MiscPickit { get; set; } = new ToggleNode(true);
+    [Menu("Misc Pickit Range", "Range at which we will pickit things that are not items (doors, chests, etc)")]
+    [ConditionalDisplay(nameof(MiscPickit), true)]
+    public RangeNode<int> MiscPickitRange { get; set; } = new RangeNode<int>(15, 0, 600);
+    [ConditionalDisplay(nameof(MiscPickit), true)]
     [Menu("Click Chests", "Will click chests if enabled")]
     public ToggleNode ClickChests { get; set; } = new ToggleNode(true);
+    [ConditionalDisplay(nameof(MiscPickit), true)]
     [Menu("Click Doors", "Will click doors if enabled")]
     public ToggleNode ClickDoors { get; set; } = new ToggleNode(true);
     [Menu("Click Transitions", "Will click area/zone transitions if enabled")]
-    public ToggleNode ClickTransitions { get; set; } = new ToggleNode(true);
+    [ConditionalDisplay(nameof(MiscPickit), true)]
+    public ToggleNode ClickTransitions { get; set; } = new ToggleNode(false);
+    [ConditionalDisplay(nameof(MiscPickit), true)]
     [Menu("Click Corpses", "Will click corpses if enabled")]
     public ToggleNode ClickCorpses { get; set; } = new ToggleNode(true);
+    [ConditionalDisplay(nameof(MiscPickit), true)]
+    [Menu("Click Portals", "Will click portals if enabled")]
+    public ToggleNode ClickPortals { get; set; } = new ToggleNode(false);
+    [Menu("Misc Click Delay", "How many milliseconds should pickit wait between clicks for a misc object (portal, doors, etc)")]
+    public RangeNode<int> MiscClickDelay { get; set; } = new RangeNode<int>(15000, 100, 100000);
 
     [JsonIgnore]
     public TextNode FilterTest { get; set; } = new TextNode();


### PR DESCRIPTION
* Removed old portal pickit code
* Wrote new portal pickit code
* Renamed "Pickup Range" to "Item Pickit Range" to separate any confusion users may have between item pickit and misc pickit
* Renamed itemize corpses to click corpses to maintain uniformity
* Revamped settings window with placement changes, new menu descriptors, and conditional checks
* Improved & expanded upon "misc pickit" design, to pickit non-items (chests, doors, transitions, portals)
* Also fixed a bug (I think) with "ignore while moving" as it seems to have been checking for the setting to be disabled rather then enabled